### PR TITLE
Github pages instruction enhancements

### DIFF
--- a/docs/deployments/ghpages.md
+++ b/docs/deployments/ghpages.md
@@ -13,7 +13,7 @@ sidebar_position: 3
 - Push your code to Github by using the commands from your Github repository.
 ![w:700](./img/settings.PNG)
 
-#### 3. Vite config 
+#### 3. Project config 
 - Open you app's `vite.config.js` file and add the `base` property. The value is the name of your repository with leading and trailing slashes.
 ```js
 export default defineConfig({
@@ -32,6 +32,26 @@ export default defineConfig({
 ```json
 "homepage": "https://{username}.github.io/{repo-name}/"
 ```
+
+:::note[If the project uses React Router: Note 1 ]
+
+  GitHub Pages does not support React Router `browserRouter`. You can use `hashRouter` from the same library instead.
+
+:::
+
+:::note[If the project uses React Router: Note 2]
+
+  Since the application is configured to be deployed to a subdirectory (the `base` definition above), it is necessary to tell the router what the base path is. It can be defined by giving `createBrowserRouter`/`createHashRouter` a second parameter that defines the basename. Refer to [React Router createBrowserRouter documentation](https://reactrouter.com/en/main/routers/create-browser-router#basename) for more information.
+
+  Vite sets the base path in environment variable `BASE_URL`. You can define the second parameter using the environment variable  as follows to make routing work both on localhost and in the publishing environment:
+
+  ```js
+  {
+    basename: import.meta.env.BASE_URL
+  }
+  ```
+
+:::
 
 #### 4. Install gh-pages 
 - Navigate to your app folder in your terminal and install ***gh-pages*** npm package as a development dependency (https://github.com/tschaub/gh-pages).
@@ -64,11 +84,6 @@ https://{username}.github.io/{repo_name}/
 ```
 - You can find the url from your repository's **Settings | Pages**
 ![](./img/ghpages_url.PNG)
-
-:::note 
-  GitHub Pages does not support React Router `browserRouter`. You can use `hashRouter` from the same library instead. 
-:::
-
 
 Different cloud service providers have their own deployment processes
 For example,

--- a/docs/deployments/ghpages.md
+++ b/docs/deployments/ghpages.md
@@ -18,7 +18,7 @@ sidebar_position: 3
 ```js
 export default defineConfig({
   //highlight-next-line
-  base: '/reactapp/',
+  base: '/{repo-name}/',
   plugins: [react()],
   test: {
     globals: true,
@@ -64,6 +64,11 @@ https://{username}.github.io/{repo_name}/
 ```
 - You can find the url from your repository's **Settings | Pages**
 ![](./img/ghpages_url.PNG)
+
+:::note 
+  GitHub Pages does not support React Router `browserRouter`. You can use `hashRouter` from the same library instead. 
+:::
+
 
 Different cloud service providers have their own deployment processes
 For example,


### PR DESCRIPTION
Base url configuration example made more specific, added not about hashRouter.